### PR TITLE
Fix role name in usage sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Installs [maven](https://maven.apache.org/). Usage:
 
     roles:
-    - { role: ornl-sava.maven, maven_version: 3.1.1 }
+    - { role: jgoodall.maven, maven_version: 3.1.1 }
 
 See `defaults/main.yml` file for list of all options.
 


### PR DESCRIPTION
There is no ornl-sava.maven role in Ansible Galaxy, but there's jgoodall.maven .
